### PR TITLE
Allow creating only either a Question or a PR in a KQ

### DIFF
--- a/moocng/static/js/teacheradmin/units-views.js
+++ b/moocng/static/js/teacheradmin/units-views.js
@@ -676,6 +676,10 @@ if (_.isUndefined(window.MOOC)) {
                 if (this.model.has("questionInstance")) {
                     question = this.model.get("questionInstance");
                     this.$el.find("#noquestion").addClass("hide");
+                    /* A KQ can only have a question OR a peer review, so if it has
+                       a question, the peer review assignment creation button should
+                       be hidden as well */
+                    this.$el.find("#nopeerreviewassignment").addClass("hide");
                     this.$el.find("#question-tab").removeClass("hide");
                     this.$el.find("#question img").attr("src", question.get("lastFrame"));
                     if (question.has("solutionVideo") && question.get("solutionVideo") !== "") {
@@ -704,6 +708,10 @@ if (_.isUndefined(window.MOOC)) {
                     assignment = this.model.get("peerReviewAssignmentInstance");
                     this.$el.find("#peer-review-assignment-tab").removeClass("hide");
                     this.$el.find("#nopeerreviewassignment").addClass("hide");
+                    /* A KQ can only have a question OR a peer review, so if it has
+                       a peer review assignment, the question creation button should
+                       be hidden as well */
+                    this.$el.find("#noquestion").addClass("hide");
                     this.$el.find("#reviewdescription").val(assignment.get("description"));
                     this.$el.find("#reviewminreviews").val(assignment.get("minimum_reviewers"));
                     criterionList = assignment.get("_criterionList");


### PR DESCRIPTION
The option of creating a peer review assignment or a question is not shown when
one of them already exists, as the classroom view does not handle KQs with both
a peer review and a question.
